### PR TITLE
Fixed event coordinates over text/tspan elements.

### DIFF
--- a/jquery-svgpan.js
+++ b/jquery-svgpan.js
@@ -138,8 +138,8 @@
             getEventPoint = function (evt) {
                 var p = root.createSVGPoint();
 
-                p.x = evt.offsetX;
-                p.y = evt.offsetY;
+                p.x = evt.originalEvent.clientX - root.getBoundingClientRect().left;
+                p.y = evt.originalEvent.clientY - root.getBoundingClientRect().top;
 
                 return p;
             },


### PR DESCRIPTION
Browsers handle event targets and offset coordinates differently.  This fix simply uses the event's original event client coordinates and the root SVG's client rect to calculate the actual mouse position in the SVG.
