### PR TITLE
fixed JQuery 1.9 support

### DIFF
--- a/jquery-svgpan.js
+++ b/jquery-svgpan.js
@@ -338,13 +338,8 @@
 
             //if (navigator.userAgent.toLowerCase().indexOf('webkit') >= 0) {
 
-            if ($.browser.webkit) {
-                window.addEventListener('mousewheel', handleMouseWheel, false); // Chrome/Safari
-            } else if ($.browser.mozilla) {
-                window.addEventListener('DOMMouseScroll', handleMouseWheel, false); // Firefox
-            } else {
-                window.addEventListener('mousewheel', handleMouseWheel, false); // others (Opera, Explorer9)
-            }
+            window.addEventListener('mousewheel', handleMouseWheel, false); // Chrome/Safari/others
+            window.addEventListener('DOMMouseScroll', handleMouseWheel, false); // Firefox
 
         };
 


### PR DESCRIPTION
-removed use of $.browser in mouse wheel event bindings because $.browser is no longer included in JQuery 1.9
