### PR TITLE
Update to use jQuery 1.9.1, as in jquery-svgpan.js, d3 geom fix

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -3,11 +3,10 @@
 <html>
   <head>
     <!-- jQuery -->
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 
     <!-- d3 -->
     <script type="text/javascript" src="http://mbostock.github.com/d3/d3.js"></script>
-    <script type="text/javascript" src="http://mbostock.github.com/d3/d3.geom.js"></script>
 
     <script type="text/javascript" src="jquery-svgpan.js"></script>
     <title>jquery-svgpan Demo</title>


### PR DESCRIPTION
Now uses jQuery 1.9.1, reflects switch to 1.9 in jquery-svgpan.js file
Removed script tag for d3 geom, no longer separate from d3.js
