### PR TITLE
get pointer position via evt.pageX/Y - $parent.offset()

### DIFF
--- a/jquery-svgpan.js
+++ b/jquery-svgpan.js
@@ -152,20 +152,10 @@
                  */
                 getEventPoint = function (evt) {
                     var p = root.createSVGPoint(),
-                        offsetX = evt.offsetX,
-                        offsetY = evt.offsetY,
-                        offset,
-                        ctm,
-                        matrix;
+                        offset = $parent.offset();
 
-                    if (typeof offsetX === "undefined" || typeof offsetY === "undefined") {
-                        offset = offsetIsBroken ? $parent.offset() : recentOffset;
-                        offsetX = evt.pageX - offset.left;
-                        offsetY = evt.pageY - offset.top;
-                    }
-
-                    p.x = offsetX;
-                    p.y = offsetY;
+                    p.x = evt.pageX - offset.left;
+                    p.y = evt.pageY - offset.top;
 
                     return p;
                 },


### PR DESCRIPTION
For IE(9,11) & FF(26), in the [official demoe](http://blog.accursedware.com/jquery-svgpan/demo.html), upon drag or zoom, if the starting position of the pointer is inside an svg circle, you would see that the pointer would be out of the cirle after the drag (or zoom).

It looks this is caused by the function `getEventPoint` returns wrong data.

From my previous experience, I changed it to simply get the event pointer position via evt.pageX/Y by substracting the offset of the svg (`$parent.offset()`).

With this change, both drag and zoom work in FF and IE and there's no impact to Chrome.
